### PR TITLE
Make conversion of date through enum or class as configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
 <!--   <version>10.7.2-SNAPSHOT</version>-->
 
-    <version>10.7.3-28</version>
+    <version>10.7.3-33</version>
 
     <name>kafka-connect-jdbc</name>
     <organization>

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -268,6 +268,10 @@ public class JdbcSinkConfig extends AbstractConfig {
     private static final boolean SKIP_DATA_LOAD_DEFAULT = false;
     private static final String SKIP_DATA_LOAD_DOC = "Skip data loading to the destination database";
 
+    public static final String DATE_CONVERSION_BY_ENUM = "date.conversion.by.enum";
+    private static final boolean DATE_CONVERSION_BY_ENUM_DEFAULT =  false;
+    private static final String DATE_CONVERSION_BY_ENUM_DOC = "To use enum for date conversion of not";
+
     protected ConnectionURLParser dbConnection;
 
 
@@ -1078,7 +1082,8 @@ public class JdbcSinkConfig extends AbstractConfig {
             .define(INSERT_COLUMN_EXCLUDE_LIST, ConfigDef.Type.STRING, INSERT_COLUMN_EXCLUDE_LIST_DEFAULT, ConfigDef.Importance.MEDIUM, INSERT_COLUMN_EXCLUDE_LIST_DOC, WRITES_GROUP, 1, ConfigDef.Width.LONG, INSERT_COLUMN_EXCLUDE_LIST_DISPLAY)
             .define(GP_FAST_MATCH, ConfigDef.Type.BOOLEAN, GP_FAST_MATCH_DEFAULT, ConfigDef.Importance.MEDIUM, GP_FAST_MATCH_DOC, WRITES_GROUP, 1, ConfigDef.Width.MEDIUM, GP_FAST_MATCH_DISPLAY)
             .define(GP_REUSE_TABLE, ConfigDef.Type.BOOLEAN, GP_REUSE_TABLE_DEFAULT, ConfigDef.Importance.MEDIUM, GP_REUSE_TABLE_DOC, WRITES_GROUP, 1, ConfigDef.Width.MEDIUM, GP_REUSE_TABLE_DISPLAY)
-            .define(SKIP_DATA_LOAD_CONFIG, ConfigDef.Type.BOOLEAN, SKIP_DATA_LOAD_DEFAULT, ConfigDef.Importance.MEDIUM, SKIP_DATA_LOAD_DOC);
+            .define(SKIP_DATA_LOAD_CONFIG, ConfigDef.Type.BOOLEAN, SKIP_DATA_LOAD_DEFAULT, ConfigDef.Importance.MEDIUM, SKIP_DATA_LOAD_DOC)
+            .define(DATE_CONVERSION_BY_ENUM, ConfigDef.Type.BOOLEAN, DATE_CONVERSION_BY_ENUM_DEFAULT, ConfigDef.Importance.HIGH, DATE_CONVERSION_BY_ENUM_DOC);
     public static void printConfigDefTable(ConfigDef configDef) {
 
         System.out.format("%-30s %-20s %-30s %-15s %-50s%n", "Name", "Type", "Default", "Importance", "Documentation");
@@ -1141,6 +1146,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     public final boolean gpssUseStickySession;
     private static final Logger log = LoggerFactory.getLogger(JdbcSinkConfig.class);
     public final boolean skipDataLoad;
+    public final boolean dateConversionByEnum;
 
     public boolean printDebugLogs;
 
@@ -1249,6 +1255,7 @@ public class JdbcSinkConfig extends AbstractConfig {
                     + "Execute 'greenplum_path.sh' found in the greenplum installation directory and restart Connect.");
         }
         skipDataLoad = getBoolean(SKIP_DATA_LOAD_CONFIG);
+        dateConversionByEnum = getBoolean(DATE_CONVERSION_BY_ENUM);
 
         keepGpFiles = getBoolean(KEEP_GP_FILES_CONFIG);
 

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/DateTypeConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/DateTypeConverter.java
@@ -1,0 +1,82 @@
+package io.confluent.connect.jdbc.sink.metadata;
+
+import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DateTypeConverter {
+
+    private static final Logger log = LoggerFactory.getLogger(DateTypeConverter.class);
+    private final Map<String, Converter> converters;
+
+    public DateTypeConverter() {
+        converters = new HashMap<>();
+        converters.put("date", new DateConverter());
+        converters.put("time", new TimeConverter());
+        converters.put("timestamp", new TimestampConverter());
+    }
+
+    public String format(JdbcSinkConfig config, String type, String dateValue) {
+        Converter converter = converters.get(type.toLowerCase());
+        if (converter != null) {
+            return converter.format(config, dateValue);
+        }
+        return dateValue;
+    }
+
+    private interface Converter {
+        String format(JdbcSinkConfig config, String dateValue);
+    }
+
+    private static class DateConverter implements Converter {
+        @Override
+        public String format(JdbcSinkConfig config, String dateValue) {
+            log.info("Converting date...");
+            return convertDateFormat(config, dateValue, config.dateFromFormat, config.dateToFormat, config.dateFromTimezone, config.dateToTimezone);
+        }
+    }
+
+    private static class TimeConverter implements Converter {
+        @Override
+        public String format(JdbcSinkConfig config, String dateValue) {
+            log.info("Converting time...");
+            return convertDateFormat(config, dateValue, config.timeFromFormat, config.timeToFormat, config.dateFromTimezone, config.dateToTimezone);
+        }
+    }
+
+    private static class TimestampConverter implements Converter {
+        @Override
+        public String format(JdbcSinkConfig config, String dateValue) {
+            log.info("Converting timestamp...");
+            return convertDateFormat(config, dateValue, config.timestampFromFormat, config.timestampToFormat, config.dateFromTimezone, config.dateToTimezone);
+        }
+    }
+
+    private static String convertDateFormat(JdbcSinkConfig config, String originalDateString, String originalFormat, String targetFormat, java.util.TimeZone fromTimeZone, java.util.TimeZone toTimeZone) {
+        if (config.printDebugLogs) {
+            log.info("Converting: originalDateString: {} originalFormat: {} targetFormat: {}", originalDateString, originalFormat, targetFormat);
+        }
+        if (originalDateString == null || originalFormat == null || targetFormat == null || originalDateString.isEmpty() || originalFormat.isEmpty() || targetFormat.isEmpty() || "null".equalsIgnoreCase(originalDateString)) {
+            return originalDateString;
+        }
+
+        SimpleDateFormat originalFormatter = new SimpleDateFormat(originalFormat);
+        if (fromTimeZone != null) originalFormatter.setTimeZone(fromTimeZone);
+
+        SimpleDateFormat targetFormatter = new SimpleDateFormat(targetFormat);
+        if (toTimeZone != null) targetFormatter.setTimeZone(toTimeZone);
+
+        try {
+            Date parsedDate = originalFormatter.parse(originalDateString);
+            return targetFormatter.format(parsedDate);
+        } catch (Exception e) {
+            log.error("Date conversion failed", e);
+            return originalDateString;
+        }
+    }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/DateTypeConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/DateTypeConverter.java
@@ -6,33 +6,30 @@ import org.slf4j.LoggerFactory;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 public class DateTypeConverter {
     private final Logger log = LoggerFactory.getLogger(DateTypeConverter.class);
 
     private final JdbcSinkConfig config;
+
     public DateTypeConverter(JdbcSinkConfig config) {
         this.config = config;
     }
 
+    public String convertDate(String dateValue) {
+        log.info("Converting date...");
+        return convertDateFormat(dateValue, config.dateFromFormat, config.dateToFormat, config.dateFromTimezone, config.dateToTimezone);
+    }
 
+    public String convertTime(String dateValue) {
+        log.info("Converting time...");
+        return convertDateFormat(dateValue, config.timeFromFormat, config.timeToFormat, config.dateFromTimezone, config.dateToTimezone);
+    }
 
-        public String convertDate(String dateValue) {
-            log.info("Converting date...");
-            return convertDateFormat(dateValue, config.dateFromFormat, config.dateToFormat, config.dateFromTimezone, config.dateToTimezone);
-        }
-
-        public String convertTime(String dateValue) {
-            log.info("Converting time...");
-            return convertDateFormat(dateValue, config.timeFromFormat, config.timeToFormat, config.dateFromTimezone, config.dateToTimezone);
-        }
-
-        public String convertTimeStamp(String dateValue) {
-            log.info("Converting timestamp...");
-            return convertDateFormat(dateValue, config.timestampFromFormat, config.timestampToFormat, config.dateFromTimezone, config.dateToTimezone);
-        }
+    public String convertTimeStamp(String dateValue) {
+        log.info("Converting timestamp...");
+        return convertDateFormat(dateValue, config.timestampFromFormat, config.timestampToFormat, config.dateFromTimezone, config.dateToTimezone);
+    }
 
     private synchronized String convertDateFormat(String originalDateString, String originalFormat, String targetFormat, java.util.TimeZone fromTimeZone, java.util.TimeZone toTimeZone) {
         if (config.printDebugLogs) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/DateTypeConverter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/DateTypeConverter.java
@@ -10,54 +10,31 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class DateTypeConverter {
+    private final Logger log = LoggerFactory.getLogger(DateTypeConverter.class);
 
-    private static final Logger log = LoggerFactory.getLogger(DateTypeConverter.class);
-    private final Map<String, Converter> converters;
-
-    public DateTypeConverter() {
-        converters = new HashMap<>();
-        converters.put("date", new DateConverter());
-        converters.put("time", new TimeConverter());
-        converters.put("timestamp", new TimestampConverter());
+    private final JdbcSinkConfig config;
+    public DateTypeConverter(JdbcSinkConfig config) {
+        this.config = config;
     }
 
-    public String format(JdbcSinkConfig config, String type, String dateValue) {
-        Converter converter = converters.get(type.toLowerCase());
-        if (converter != null) {
-            return converter.format(config, dateValue);
-        }
-        return dateValue;
-    }
 
-    private interface Converter {
-        String format(JdbcSinkConfig config, String dateValue);
-    }
 
-    private static class DateConverter implements Converter {
-        @Override
-        public String format(JdbcSinkConfig config, String dateValue) {
+        public String convertDate(String dateValue) {
             log.info("Converting date...");
-            return convertDateFormat(config, dateValue, config.dateFromFormat, config.dateToFormat, config.dateFromTimezone, config.dateToTimezone);
+            return convertDateFormat(dateValue, config.dateFromFormat, config.dateToFormat, config.dateFromTimezone, config.dateToTimezone);
         }
-    }
 
-    private static class TimeConverter implements Converter {
-        @Override
-        public String format(JdbcSinkConfig config, String dateValue) {
+        public String convertTime(String dateValue) {
             log.info("Converting time...");
-            return convertDateFormat(config, dateValue, config.timeFromFormat, config.timeToFormat, config.dateFromTimezone, config.dateToTimezone);
+            return convertDateFormat(dateValue, config.timeFromFormat, config.timeToFormat, config.dateFromTimezone, config.dateToTimezone);
         }
-    }
 
-    private static class TimestampConverter implements Converter {
-        @Override
-        public String format(JdbcSinkConfig config, String dateValue) {
+        public String convertTimeStamp(String dateValue) {
             log.info("Converting timestamp...");
-            return convertDateFormat(config, dateValue, config.timestampFromFormat, config.timestampToFormat, config.dateFromTimezone, config.dateToTimezone);
+            return convertDateFormat(dateValue, config.timestampFromFormat, config.timestampToFormat, config.dateFromTimezone, config.dateToTimezone);
         }
-    }
 
-    private static String convertDateFormat(JdbcSinkConfig config, String originalDateString, String originalFormat, String targetFormat, java.util.TimeZone fromTimeZone, java.util.TimeZone toTimeZone) {
+    private synchronized String convertDateFormat(String originalDateString, String originalFormat, String targetFormat, java.util.TimeZone fromTimeZone, java.util.TimeZone toTimeZone) {
         if (config.printDebugLogs) {
             log.info("Converting: originalDateString: {} originalFormat: {} targetFormat: {}", originalDateString, originalFormat, targetFormat);
         }


### PR DESCRIPTION
## Problem
We were using enum for conversion of date/time/timestamp, which was causing some issues during high throttle runs.

## Solution
We have implemented a solution in which instead of using an enum, we will be using a class for conversion of date/time/timestamp.